### PR TITLE
🐛 FIX: Changed inexistent String.strip method for trim

### DIFF
--- a/src/server/controllers/adminController.js
+++ b/src/server/controllers/adminController.js
@@ -209,7 +209,7 @@ module.exports.importProfessors = async (req, res, next) => {
 			}
 
 			professor.subjectId.forEach(async (subject) => {
-				if (!currentBallots.find(b => b.professorId.strip().toLowerCase() === professor.id.strip().toLowerCase() && parseInt(b.subjectId, 10) === parseInt(subject, 10))) {
+				if (!currentBallots.find(b => b.professorId.trim().toLowerCase() === professor.id.trim().toLowerCase() && parseInt(b.subjectId, 10) === parseInt(subject, 10))) {
 					await models.Ballot.create({
 						academicYear, professorId: professor.id, subjectId: subject, degreeId,
 					});


### PR DESCRIPTION
I've noticed in the logs that at the importProfessors method inside the admin controller a  `TypeError: <String>.strip is not a function` was ocurring.

I've changed the calls `strip()` to call `trim()`, a method that can also **remove unwanted whitespaces** and **belongs to javascript.**